### PR TITLE
Improve blue stack adb port identification, upgrade .NET to 7 version

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,26 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      // Use IntelliSense to find out which attributes exist for C# debugging
+      // Use hover for the description of the existing attributes
+      // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+      "name": ".NET Core Launch (console)",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build",
+      // If you have changed target frameworks, make sure to update the program path.
+      "program": "${workspaceFolder}/MacrorifyServiceInstaller/bin/Debug/netcoreapp7.0/MacrorifyServiceInstaller.dll",
+      "args": [],
+      "cwd": "${workspaceFolder}/MacrorifyServiceInstaller",
+      // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
+      "console": "externalTerminal",
+      "stopAtEntry": false
+    },
+    {
+      "name": ".NET Core Attach",
+      "type": "coreclr",
+      "request": "attach"
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,41 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "build",
+        "${workspaceFolder}/MacrorifyServiceInstaller/MacrorifyServiceInstaller.csproj",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "publish",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "publish",
+        "${workspaceFolder}/MacrorifyServiceInstaller/MacrorifyServiceInstaller.csproj",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "watch",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "watch",
+        "run",
+        "--project",
+        "${workspaceFolder}/MacrorifyServiceInstaller/MacrorifyServiceInstaller.csproj"
+      ],
+      "problemMatcher": "$msCompile"
+    }
+  ]
+}

--- a/MacrorifyServiceInstaller/Connecter/ConnecterBlue.cs
+++ b/MacrorifyServiceInstaller/Connecter/ConnecterBlue.cs
@@ -1,34 +1,80 @@
-﻿using SharpAdbClient;
-using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System;
+using System.IO;
+using System.Text.RegularExpressions;
 
 namespace MacrorifyServiceInstaller
 {
-    public class ConnecterBlue : IConnector
+  public class ConnecterBlue : IConnector
+  {
+    static string BluestacksConfigFilePath => Path.Join(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), @"BlueStacks_nxt\bluestacks.conf");
+    static Regex AdbPortExtraction = new Regex(@"bst\.instance.(.+)\.adb_port=""(?<adbPort>\d+)""", RegexOptions.IgnoreCase);
+
+    public ConnecterBlue()
     {
-        public ConnecterBlue()
-        {
-        }
-
-        public void Connect()
-        {
-            for (var i = 0; i < 5; i += 1)
-            {
-                try
-                {
-                    AdbHelper.GetClient().Connect(new System.Net.DnsEndPoint(Constant.LOCALHOST, Constant.BLUE_PORT + i));
-                }
-                catch { /*ignored*/ }
-            }
-
-            for (var i = 10; i <= 100; i += 10)
-            {             
-                try
-                {
-                    AdbHelper.GetClient().Connect(new System.Net.DnsEndPoint(Constant.LOCALHOST, Constant.BLUE_PORT + i));
-                } catch { /*ignored*/ }
-            }
-        }
     }
+
+    public void Connect()
+    {
+
+      if (FindAdbPortInConfig(out int bluePort))
+      {
+        if (TryConnectAdbClient(bluePort))
+        {
+          return;
+        }
+      }
+
+      for (var i = 0; i < 5; i += 1)
+      {
+        if (TryConnectAdbClient(Constant.BLUE_PORT + i))
+        {
+          return;
+        }
+      }
+
+      for (var i = 10; i <= 100; i += 10)
+      {
+        if (TryConnectAdbClient(Constant.BLUE_PORT + i))
+        {
+          return;
+        }
+      }
+    }
+
+    private static bool TryConnectAdbClient(int port)
+    {
+      try
+      {
+        AdbHelper.GetClient().Connect(new System.Net.DnsEndPoint(Constant.LOCALHOST, port));
+        return true;
+      }
+      catch { /*ignored*/ }
+
+      return false;
+    }
+
+    private bool FindAdbPortInConfig(out int adbPort)
+    {
+      adbPort = Constant.BLUE_PORT;
+      if (!File.Exists(BluestacksConfigFilePath))
+        return false;
+
+      try
+      {
+        foreach (var line in File.ReadAllLines(BluestacksConfigFilePath))
+        {
+          // match any Android version by pattern of "bst.instance.(.*).adb_port="5555""
+          var match = AdbPortExtraction.Match(line);
+          if (match.Success)
+          {
+            adbPort = Convert.ToInt32(match.Groups["adbPort"].Value);
+            return true;
+          }
+        }
+      }
+      catch { /*ignored*/ }
+
+      return false;
+    }
+  }
 }

--- a/MacrorifyServiceInstaller/MacrorifyServiceInstaller.csproj
+++ b/MacrorifyServiceInstaller/MacrorifyServiceInstaller.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp7.0</TargetFramework>
     <ApplicationIcon>icon.ico</ApplicationIcon>
   </PropertyGroup>
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MacrorifyServiceInstaller
 Native Service Installer for Macrorify: https://play.google.com/store/apps/details?id=com.kok_emm.mobile
 
-The Service is just my fork of minitouch which add image capture in: https://github.com/Kok3995/minitouch
+The Service is just my fork of minitouch which adds image capture in: https://github.com/Kok3995/minitouch
 
 # Prerequisite
-- .NET Runtime: https://dotnet.microsoft.com/download/dotnet/3.1
+- .NET Runtime: https://dotnet.microsoft.com/download/dotnet/7.0


### PR DESCRIPTION
The new BlueStack versions use dynamic adb port allocation ([reddit thread](https://www.reddit.com/r/BlueStacks/comments/qzlhg9/comment/i7vp6lz/)). This code supports the attempt to identify adb port based on the standard configuration location (`bluestacks.conf`); otherwise, fallback into the previous process.